### PR TITLE
Use barrier.Forward to signal container shutdown

### DIFF
--- a/container.go
+++ b/container.go
@@ -27,7 +27,7 @@ type Container struct {
 	errorsW chan<- error
 }
 
-func NewContainer(client *docker.Client, name string, wg *sync.WaitGroup, dying *barrier.Barrier) *Container {
+func NewContainer(client *docker.Client, name string, wg *sync.WaitGroup) *Container {
 
 	errors := make(chan error)
 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ type Options struct {
 func main() {
 
 	options := Options{
-		env:     opts.NewListOpts(nil),
+		env: opts.NewListOpts(nil),
 	}
 	mflag.Var(&options.env, []string{"e", "-env"}, "Set environment variables")
 
@@ -110,7 +110,7 @@ func loop(wg *sync.WaitGroup, dying *barrier.Barrier, options Options) {
 
 	for {
 
-		c := NewContainer(client, getName(), wg, dying)
+		c := NewContainer(client, getName(), wg)
 		c.Env = env
 
 		// Global exit should cause container exit


### PR DESCRIPTION
This is an improvement since it means fewer goroutines in any full stack dumps
and also the placement of the forward has been moved so that really "main" owns
the dying semantics rather than the container.
# Ready for merging
