### PR TITLE
Read env variables for sockets; README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Then launch it (in a directory with a Dockerfile!):
 
 $ ./hanoverd
 
+Environment variables which the docker client (and boot2docker) use
+can be set first.
+
+  DOCKER\_CERT\_PATH
+  DOCKER\_HOST
+  DOCKER\_TLS\_VERIFY
+
 ## Method
 
 * Hanoverd is responsible for listening on externally visible sockets and

--- a/main.go
+++ b/main.go
@@ -86,7 +86,31 @@ func loop(wg *sync.WaitGroup, dying *barrier.Barrier, options Options) {
 	sig := make(chan os.Signal)
 	signal.Notify(sig, os.Interrupt)
 
-	client, err := docker.NewClient("unix:///run/docker.sock")
+	docker_host := os.Getenv("DOCKER_HOST")
+	if docker_host == "" {
+		docker_host = "unix:///run/docker.sock"
+	}
+
+	docker_tls_verify := os.Getenv("DOCKER_TLS_VERIFY")
+	docker_tls_verify_bool := false
+	if docker_tls_verify != "" {
+		docker_tls_verify_bool = true
+	}
+
+	var client *docker.Client
+	var err error
+	if docker_tls_verify_bool {
+		docker_cert_path := os.Getenv("DOCKER_CERT_PATH")
+		docker_cert := docker_cert_path + "/cert.pem"
+		docker_key := docker_cert_path + "/key.pem"
+		// TODO there's no environment variable option in docker client for
+		// this, it's called -tlscacert in its command line. We'll leave it
+		// as the default (no CA, just trust) which boot2docker uses.
+		docker_ca := ""
+		client, err = docker.NewTLSClient(docker_host, docker_cert, docker_key, docker_ca)
+	} else {
+		client, err = docker.NewClient(docker_host)
+	}
 	if err != nil {
 		dying.Fall()
 		log.Println("Connecting to Docker failed:", err)


### PR DESCRIPTION
Although now I've done it, of course it still won't work as I'm going to need
iptables on the same machine... So realistically will be on its default socket.
