### PR TITLE
Fixes for running under systemd

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,6 +130,15 @@ func main() {
 		}
 	}()
 
+	// SIGTERM handler
+	go func() {
+		defer dying.Fall()
+		defer log.Println("Received SIGTERM")
+		sig := make(chan os.Signal)
+		signal.Notify(sig, syscall.SIGTERM)
+		<-sig
+	}()
+
 	go loop(&wg, &dying, options, events)
 	go httpInterface(events)
 


### PR DESCRIPTION
Hanoverd running under systemd exited immediately because stdin was not
connected.

Also, SIGTERM resulted in an unclean shutdown.

This PR fixes both of these issues.
