### PR TITLE
Fix for regression of #50

### DIFF
--- a/container.go
+++ b/container.go
@@ -98,7 +98,6 @@ func makeBinds(in []string) []string {
 // `docker create` the container.
 func (c *Container) Create(imageName string) error {
 	opts := docker.CreateContainerOptions{
-		Name: c.Name,
 		Config: &docker.Config{
 			Hostname:     c.Name,
 			AttachStdout: true,
@@ -107,35 +106,15 @@ func (c *Container) Create(imageName string) error {
 			Cmd:          c.Args,
 			Image:        imageName,
 			Volumes:      makeVolumeSet(c.Volumes),
+			Labels: map[string]string{
+				"orchestrator":  "hanoverd",
+				"hanoverd-name": c.Name,
+			},
 		},
 	}
 
 	var err error
-
 	c.container, err = c.client.CreateContainer(opts)
-
-	switch err := err.(type) {
-	case *docker.Error:
-		if err.Status == http.StatusConflict {
-
-			log.Printf("Container already exists, removing old one: %q", c.Name)
-			// Remove the old one and try again
-			err := c.client.RemoveContainer(docker.RemoveContainerOptions{
-				Force: true, ID: c.Name,
-			})
-
-			if err != nil {
-				return fmt.Errorf("duplicate container, failed to remove other: %v", err)
-			}
-
-			// Try again
-			c.container, err = c.client.CreateContainer(opts)
-
-			return err
-		}
-	default:
-	}
-
 	return err
 }
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/codegangsta/cli"
-	"github.com/docker/docker/nat"
+	"github.com/docker/docker/pkg/nat"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/pwaller/barrier"
 	"github.com/scraperwiki/hookbot/pkg/listen"


### PR DESCRIPTION
The fix for #50 broke again because of a change in docker.

This update improves the situation by avoiding container names
altogether, instead applying a label to the container to indicate
who created it.