### PR TITLE
Use fragment part of Hookbot URL to specify build root

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,9 +147,13 @@ func ActionBuilder(c *cli.Context) {
 		log.Fatalf("Unable to connect to docker: %v", err)
 	}
 
+	hookbotURL := c.String("listen")
+	// Remove the #anchor part of the URL, if specified.
+	hookbotURL = strings.SplitN(hookbotURL, "#", 2)[0]
+
 	finish := make(chan struct{})
 	header := http.Header{}
-	events, errs := listen.RetryingWatch(c.String("listen"), header, finish)
+	events, errs := listen.RetryingWatch(hookbotURL, header, finish)
 
 	go func() {
 		defer close(finish)

--- a/sources.go
+++ b/sources.go
@@ -81,11 +81,16 @@ func (s *DockerPullSource) Obtain(c *docker.Client, payload []byte) (string, err
 }
 
 type GitHostSource struct {
-	Host, User, Repository, InitialBranch string
+	Host          string
+	User          string
+	Repository    string
+	InitialBranch string
+	// Directory in which to do `docker build`.
+	// Uses repository root if blank.
+	ImageRoot string
 }
 
 func (s *GitHostSource) CloneURL() string {
-
 	format := "https://%s/%s/%s"
 	if HaveSSHKey() {
 		format = "ssh://git@%s/%s/%s"
@@ -133,8 +138,9 @@ func (s *GitHostSource) Obtain(c *docker.Client, payload []byte) (string, error)
 	defer build.Cleanup()
 
 	dockerImage := fmt.Sprintf("%s:%s", s.Repository, build.Name)
+	buildPath := filepath.Join(build.Dir, s.ImageRoot)
 
-	err = DockerBuildDirectory(c, dockerImage, build.Dir)
+	err = DockerBuildDirectory(c, dockerImage, buildPath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This solves the problem of how to build images where the build context
is not the root of the repository.

The format is like so:

```
/sub/github.com/repo/scraperwiki/foo/branch/master#path/to/DockerfileDir/
```