### PR TITLE
Don't use stdout for any executed commands and notify user of created directory

### DIFF
--- a/builder/git/git.go
+++ b/builder/git/git.go
@@ -21,13 +21,13 @@ import (
 
 const GIT_BASE_DIR = "repo"
 
-// Invoke a `command` in `workdir` with `args`, connecting up its Stdout and Stderr
+// Invoke a `command` in `workdir` with `args`, connecting Stdout and Stderr to Stderr.
 func Command(workdir, command string, args ...string) *exec.Cmd {
 	// log.Printf("wd = %s cmd = %s, args = %q", workdir, command, append([]string{}, args...))
 
 	cmd := exec.Command(command, args...)
 	cmd.Dir = workdir
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	return cmd
 }

--- a/cmd/git-prep-directory/main.go
+++ b/cmd/git-prep-directory/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/scraperwiki/hanoverd/builder/git"
@@ -47,4 +48,5 @@ func ActionMain(c *cli.Context) {
 		log.Fatalln("Error:", err)
 	}
 	log.Printf("Checked out %v at %v", where.Name, where.Dir)
+	fmt.Printf("%v", where.Dir)
 }


### PR DESCRIPTION
Example of this is:

    cd $(git-prep-directory --url https://github.com/scraperwiki/pdftables.com.git --ref dev 2> /dev/null)