### PR TITLE
Add a version number to CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 
 	app.Name = "hanoverd"
 	app.Usage = "handover docker containers"
+	app.Version = "0.7.9"
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{


### PR DESCRIPTION
This would be useful where you are in an unfamiliar
environment (e.g. CloudFormation generated instance)
and want to check the hanoverd version that's available.

(However, I'm aware there's #60 to resolve too.)