### PR TITLE
Use latest annotated git tag as build version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,5 @@ RUN xargs go install -installsuffix=static -v < /go/src/github.com/scraperwiki/h
 COPY . /go/src/github.com/scraperwiki/hanoverd/
 
 RUN go install -x -v -installsuffix=static \
-                -ldflags "-X main.appVersion=`git --git-dir /go/src/github.com/scraperwiki/hanoverd/.git describe --abbrev=0 --tags`" \
 		github.com/scraperwiki/hanoverd && \
 	goupx /go/bin/hanoverd

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ RUN xargs go install -installsuffix=static -v < /go/src/github.com/scraperwiki/h
 COPY . /go/src/github.com/scraperwiki/hanoverd/
 
 RUN go install -x -v -installsuffix=static \
+                -ldflags "-X main.appVersion=`git --git-dir /go/src/github.com/scraperwiki/hanoverd/.git describe --abbrev=0 --tags`" \
 		github.com/scraperwiki/hanoverd && \
 	goupx /go/bin/hanoverd

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 buildtime: .FORCE
+	go generate
 	docker build -t hanoverd-buildtime .
 	docker run --rm hanoverd-buildtime cat /go/bin/hanoverd > ./hanoverd
 	chmod u+x ./hanoverd

--- a/main.go
+++ b/main.go
@@ -63,11 +63,16 @@ func IsStdinReadable() bool {
 	return err != io.EOF
 }
 
+// appVersion set at build from latest annotated git tag.
+var appVersion string
+
 func main() {
 	app := cli.NewApp()
 
 	app.Name = "hanoverd"
 	app.Usage = "handover docker containers"
+
+	app.Version = appVersion
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{

--- a/main.go
+++ b/main.go
@@ -63,16 +63,14 @@ func IsStdinReadable() bool {
 	return err != io.EOF
 }
 
-// appVersion set at build from latest annotated git tag.
-var appVersion string
-
 func main() {
 	app := cli.NewApp()
 
 	app.Name = "hanoverd"
 	app.Usage = "handover docker containers"
 
-	app.Version = appVersion
+	// Made by `go generate` populating version.go via `git describe`.
+	app.Version = Version
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package main
+
+var Version string = "[VERSION UNSET]"

--- a/version_generate.go
+++ b/version_generate.go
@@ -1,0 +1,3 @@
+package main
+
+//go:generate ./version_generate.sh

--- a/version_generate.sh
+++ b/version_generate.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+VERSION=$(git describe --tags --abbrev=0)
+
+cat > version.go <<EOF
+package main
+
+var Version string = "$VERSION"
+EOF


### PR DESCRIPTION
Fixes #71.

Running make uses the latest tag as the release version.