### PR TITLE
Explicitly specific go-ini import name

### DIFF
--- a/builder/git/submodule.go
+++ b/builder/git/submodule.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/vaughan0/go-ini"
+	ini "github.com/vaughan0/go-ini"
 )
 
 func PrepSubmodules(


### PR DESCRIPTION
Otherwise goimport doesn't find it and uses the vendor import path alternatives.