### PR TITLE
Propagate errors resulting when fetching submodules revs

### DIFF
--- a/builder/git/submodule.go
+++ b/builder/git/submodule.go
@@ -29,7 +29,9 @@ func PrepSubmodules(
 
 	log.Printf("Prep %v submodules", len(submodules))
 
-	GetSubmoduleRevs(gitDir, mainRev, submodules)
+	if err := GetSubmoduleRevs(gitDir, mainRev, submodules); err != nil {
+		return fmt.Errorf("GetSubmoduleRevs: %v", err)
+	}
 
 	errs := make(chan error, len(submodules))
 

--- a/builder/git/submodule.go
+++ b/builder/git/submodule.go
@@ -154,6 +154,7 @@ func GetSubmoduleRevs(gitDir, mainRev string, submodules []Submodule) error {
 
 func GetSubmoduleRev(gitDir, submodulePath, mainRev string) (string, error) {
 	cmd := Command(gitDir, "git", "ls-tree", mainRev, "--", submodulePath)
+	cmd.Stdout = nil
 
 	parts, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
Re-created this pull-request as its commits gone lost (at least in _hanoved_ but not in _git-prep-directory_). b4bf946 is required to make _hanoverd_ work.