### PR TITLE
Add warning if no ports are exposed

### DIFF
--- a/container.go
+++ b/container.go
@@ -141,6 +141,11 @@ func (c *Container) CopyOutput() error {
 // Returns `true` for success and `false` for failure.
 func (c *Container) AwaitListening() bool {
 
+	if len(c.container.NetworkSettings.PortMappingAPI()) == 0 {
+		log.Printf("Error! No ports are exposed.")
+		return false
+	}
+
 	const (
 		DefaultTimeout = 5 * time.Minute
 		PollFrequency  = 10 // times per second (via integer division of ns)


### PR DESCRIPTION
Fixes #42.

Previously, the container would just fail. Now it logs an error first, so
you know why.

I toyed also with making it not an error, but I figure since hanoverd's primary 
purpose is to run network services it is better to just fail than emit a
warning and continue.