### PR TITLE
Fix container superceding

### DIFF
--- a/main.go
+++ b/main.go
@@ -321,6 +321,7 @@ func loop(
 	go flipper(wg, options, flips)
 
 	var i int
+	supercede := func() {}
 
 	for event := range events {
 
@@ -343,6 +344,10 @@ func loop(
 
 		// Global exit should cause container exit
 		dying.Forward(&c.Closing)
+
+		// Cancel an existing startup, if there is one.
+		supercede()
+		supercede = c.Superceded.Fall
 
 		wg.Add(1)
 		go func(c *Container) {


### PR DESCRIPTION
This matters for containers which take a while to start up, where
another request may come in before the first completes (such as on the
CSPS backend during testing). It's important to kill the old one before
trying to start the next one otherwise it may run out of memory.