### PR TITLE
Implement build/runtime separation

### DIFF
--- a/example/separate-build-run/Dockerfile
+++ b/example/separate-build-run/Dockerfile
@@ -1,12 +1,21 @@
 FROM ubuntu:15.10
 
+RUN apt-get install -y netcat-openbsd
+
 RUN mkdir /runtime
 
 RUN cp --parents \
+    /bin/sh \
     /bin/dash \
-    /lib/x86_64-linux-gnu/libc.so.6 \
+    /bin/nc \
+    /bin/hostname \
+    /etc/alternatives/nc \
+    /lib64/ld-linux-x86-64.so.* \
+    /lib/x86_64-linux-gnu/libnsl*.so* \
+    /lib/x86_64-linux-gnu/libc.so.* \
+    /lib/x86_64-linux-gnu/libbsd.so.* \
+    /lib/x86_64-linux-gnu/libresolv*.so* \
     /runtime
-RUN ln -s /bin/dash /runtime/bin/sh
 
 COPY ./runtime/Dockerfile /runtime/Dockerfile
 

--- a/example/separate-build-run/Dockerfile
+++ b/example/separate-build-run/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:15.10
+
+RUN mkdir /runtime
+
+RUN cp --parents \
+    /bin/dash \
+    /lib/x86_64-linux-gnu/libc.so.6 \
+    /runtime
+RUN ln -s /bin/dash /runtime/bin/sh
+
+COPY ./runtime/Dockerfile /runtime/Dockerfile
+
+ENTRYPOINT ["tar", "--directory", "/runtime", "--create", "."]

--- a/example/separate-build-run/runtime/Dockerfile
+++ b/example/separate-build-run/runtime/Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 
-COPY . /
+EXPOSE 8000
+ENTRYPOINT ["/bin/dash", "-c", "while : ; do printf 'HTTP/1.0 200 OK\r\n\r\nHello world from %s\r\n' $(hostname) | nc -l 8000; done"]
 
-ENTRYPOINT ["/bin/dash"]
+COPY . /

--- a/example/separate-build-run/runtime/Dockerfile
+++ b/example/separate-build-run/runtime/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY . /
+
+ENTRYPOINT ["/bin/dash"]

--- a/pkg/source/sources.go
+++ b/pkg/source/sources.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	git "github.com/scraperwiki/git-prep-directory"
 )
 
@@ -156,7 +156,83 @@ func (s *GitHostSource) Obtain(c *docker.Client, payload []byte) (string, error)
 		return "", err
 	}
 
+	// Test for the presence of a 'runtime/Dockerfile' in the buildpath.
+	if exists(filepath.Join(buildPath, "runtime", "Dockerfile")) {
+
+	}
+
 	return dockerImage, nil
+}
+
+func DockerRun(c *docker.Client, imageName string) (io.ReadCloser, error) {
+	cont, err := c.CreateContainer(docker.CreateContainerOptions{
+		Config: &docker.Config{
+			Hostname:     "generateruntimecontext",
+			AttachStdout: true,
+			AttachStderr: true,
+			Image:        imageName,
+			Labels: map[string]string{
+				"orchestrator": "hanoverd",
+				"purpose":      "Generate build context for runtime container",
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.StartContainer(cont.ID, &docker.HostConfig{})
+	if err != nil {
+		return nil, err
+	}
+
+	r, w := io.Pipe()
+
+	err = c.AttachToContainer(docker.AttachToContainerOptions{
+		Container:    cont.ID,
+		OutputStream: w,
+		ErrorStream:  os.Stderr,
+		Logs:         true,
+		Stdout:       true,
+		Stderr:       true,
+		Stream:       true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: r,
+		Closer: CloseFunc(func() error {
+			status, err := c.WaitContainer(cont.ID)
+			if err != nil {
+				return err
+			}
+			if status != 0 {
+				return fmt.Errorf("non-zero exit status: %v", err)
+			}
+			return nil
+		}),
+	}, err
+}
+
+type CloseFunc func() error
+
+func (fn CloseFunc) Close() error { return fn() }
+
+func exists(filename string) bool {
+	_, err := os.Stat(filename)
+	switch {
+	case err == nil:
+		return true
+	default:
+		log.Printf("Error checking for the existence of %q: %v", filename, err)
+	case os.IsNotExist(err):
+	}
+	return false
 }
 
 // Returns true if $HOME/.ssh exists, false otherwise

--- a/version_generate.sh
+++ b/version_generate.sh
@@ -7,3 +7,6 @@ package main
 
 var Version string = "$VERSION"
 EOF
+
+# Dear git, please don't bother us with changes to this file.
+git update-index --assume-unchanged version.go


### PR DESCRIPTION
If the source directory being built for `GitHostSource` or `CwdSource` contains a `runtime/Dockerfile`, then hanoverd will first build the original directory, then run that container, using it as the build context for the runtime image, i.e:

```
docker build -t buildtime .
docker run --rm buildtime | docker build -t runtime -
```