### PR TITLE
Implement integration tests for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ install:
 
 script:
   - ls -la hanoverd
+  - GO15VENDOREXPERIMENT=1 make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: required
+
+language: go
+
+go:
+  - 1.5.1
+
+services:
+  - docker
+
+install:
+  - make
+
+script:
+  - ls -la hanoverd

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
   - docker
 
 install:
-  - make
+  - GO15VENDOREXPERIMENT=1 make
 
 script:
   - ls -la hanoverd

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,36 @@
-buildtime: .FORCE
+all: hanoverd
+
+# Compute a file that looks like "hanoverd: file.go" for all go source files
+# that hanoverd depends on.
+hanoverd.deps:
+	# 1) Get recursive list of deps.
+	# 2) Filter out stdlib.
+	# 3) Print all Go source files used in the package.
+	# 4) Use sed to only catch lines which are in this directory and remove $PWD.
+	go list -f '{{.ImportPath}}{{"\n"}}{{range .Deps}}{{.}}{{"\n"}}{{end}}' . | \
+	xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' | \
+	xargs go list -f '{{with $$p := .}}{{range .GoFiles}}{{$$p.Dir}}/{{.}}{{"\n"}}{{end}}{{end}}' | \
+	sed --quiet 's|^'$(shell pwd)/'|hanoverd: |p' > hanoverd.deps
+
+# So that make knows about hanoverd's other dependencies.
+-include hanoverd.deps
+
+hanoverd: hanoverd.deps
+	# Build hanoverd using
 	go generate
 	docker build -t hanoverd-buildtime .
 	docker run --rm hanoverd-buildtime cat /go/bin/hanoverd > ./hanoverd
-	chmod u+x ./hanoverd
+	chmod +x ./hanoverd
 
-release: buildtime .FORCE
+release: hanoverd
 	mv hanoverd hanoverd_linux_amd64
 	gphr release -keep=true hanoverd_linux_amd64
 
-.FORCE:
-.PHONY: .FORCE buildtime release
+iptables:
+	cp $(shell which iptables) .
+	sudo setcap 'cap_net_admin,cap_net_raw=+ep' iptables
+
+test: hanoverd iptables
+	@PATH=.:$(PATH) go test -v ./tests
+
+.PHONY: release test

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ iptables:
 	sudo setcap 'cap_net_admin,cap_net_raw=+ep' iptables
 
 test: hanoverd iptables
-	@PATH=.:$(PATH) go test -v ./tests
+	PATH=$$PWD:$$PATH go test -v ./tests
 
 # GNU Make instructions
 .PHONY: release test

--- a/generate-deps.sh
+++ b/generate-deps.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+
+TARGET=$1
+SOURCE=$2
+
+# Take arguments as stdin
+golist() {
+  PROG=$1
+  xargs go list -f "$PROG"
+}
+
+# Remove $PWD prefix
+make_relative() {
+  sed --quiet 's|^'$(pwd)/'||p'
+}
+
+# Prepend target: and target.deps:
+prepend_targets() {
+  sed --quiet 's|^|'${TARGET}': |p;s|^'${TARGET}':|'${TARGET}.deps':|p'
+}
+
+ALL_IMPORTS='{{.ImportPath}}{{"\n"}}{{range .Deps}}{{.}}{{"\n"}}{{end}}'
+NON_STDLIB='{{if not .Standard}}{{.ImportPath}}{{end}}'
+GO_SOURCES='{{with $p := .}}{{range .GoFiles}}{{$p.Dir}}/{{.}}{{"\n"}}{{end}}{{end}}'
+
+set -o pipefail
+
+echo "$SOURCE" |
+  golist "$ALL_IMPORTS" |
+  golist "$NON_STDLIB" |
+  golist "$GO_SOURCES" |
+  make_relative |
+  prepend_targets

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const (
+	// TCP port chosen by rolling a dice, used for listening.
+	testPort = "50820"
+)
+
+// simpleGetHTTP returns the body of a HTTP GET response from `url`, or an
+// empty string on error.
+func simpleGetHTTP(url string) string {
+	r, err := http.Get(url)
+	if err != nil {
+		return ""
+	}
+	bs, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return ""
+	}
+	return string(bs)
+}
+
+// TestCWDBuildsAdvance attempts to run hanoverd in CWD-build mode in the
+// examples directory. It checks that the hostname advances.
+func TestCWDBuildsAdvance(t *testing.T) {
+
+	examplePath, err := filepath.Abs(filepath.Join("..", "example"))
+	if err != nil {
+		t.Fatalf("Unable to determine example path: %v", err)
+	}
+
+	// Spawn hanoverd in the example directory
+
+	cmd := exec.Command("hanoverd", "--publish", testPort+":8000")
+	cmd.Dir = examplePath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Start()
+	if err != nil {
+		t.Fatalf("hanoverd failed to start, is it installed?: %v", err)
+	}
+
+	// Amount of time we're willing to wait for a state transition.
+	const timeout = 30 * time.Second
+	deadline := time.Now().Add(timeout)
+
+	current := ""
+	wanted := "Hello from hanoverd_0\r\n"
+	next := map[string]string{
+		"Hello from hanoverd_0\r\n": "Hello from hanoverd_1\r\n",
+		"Hello from hanoverd_1\r\n": "Hello from hanoverd_2\r\n",
+		// When 2 is reached,
+		"Hello from hanoverd_2\r\n": "",
+	}
+
+	// Rapidly loop doing HTTP requests.
+loop:
+	for {
+		if time.Now().After(deadline) {
+			t.Errorf("Took longer than deadline to get a valid response")
+			break
+		}
+
+		response := simpleGetHTTP("http://localhost:" + testPort)
+
+		switch response {
+		default:
+			t.Logf("Unexpected response, current = %q wanted = %q, got = %q",
+				current, wanted, response)
+		case current:
+		case wanted:
+			deadline = time.Now().Add(timeout)
+
+			current = response
+			wanted = next[response]
+
+			// Default: tell hanoverd to reload
+			sig := syscall.SIGHUP
+			if response == "Hello from hanoverd_2\r\n" {
+				// Final: send SIGTERM
+				sig = syscall.SIGTERM
+			}
+
+			err := cmd.Process.Signal(sig)
+			if err != nil {
+				t.Errorf("Failed to signal hanoverd: %v", err)
+				break loop
+			}
+
+			if sig == syscall.SIGTERM {
+				break loop
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		t.Fatalf("waiting on hanoverd: %v", err)
+	}
+
+	log.Printf("Success!")
+}


### PR DESCRIPTION
This adds integration tests and runs them on travis.

It also improves the build system so that it knows the dependencies and only rebuilds if something changed, and makes `make test` work correctly.