### PR TITLE
Update to go1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ sudo: required
 language: go
 
 go:
-  - 1.5.1
+  - 1.6
 
 services:
   - docker
 
 install:
-  - GO15VENDOREXPERIMENT=1 make
+  - make
 
 script:
   - ls -la hanoverd
-  - GO15VENDOREXPERIMENT=1 make test
+  - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-FROM golang:1.5
+FROM golang:1.6
 
 RUN apt-get update && apt-get install -y upx iptables
 
 COPY ./github-host-key /etc/ssh/ssh_known_hosts
 
-RUN go get github.com/pwaller/goupx
-
 # Turn off cgo so that we end up with totally static binaries
-ENV CGO_ENABLED=0 \
-    GO15VENDOREXPERIMENT=1
+ENV CGO_ENABLED=0
 
-RUN go install -a -installsuffix=static std
+RUN go install -v -a -installsuffix=static std
 
 COPY ./vendor /go/src/github.com/scraperwiki/hanoverd/vendor/
 COPY ./dependencies /go/src/github.com/scraperwiki/hanoverd/dependencies
@@ -21,4 +18,4 @@ COPY . /go/src/github.com/scraperwiki/hanoverd/
 
 RUN go install -x -v -installsuffix=static \
 		github.com/scraperwiki/hanoverd && \
-	goupx /go/bin/hanoverd
+	upx /go/bin/hanoverd


### PR DESCRIPTION
Also simplify the build process a bit now that goupx and vendor environment
are no longer necessary.

# ~~Rebase after #88~~