### PR TITLE
Change method for detecting process ready

### DIFF
--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -37,7 +37,6 @@ func simpleGetHTTP(url string) string {
 // TestCWDBuildsAdvance attempts to run hanoverd in CWD-build mode in the
 // examples directory. It checks that the hostname advances.
 func TestCWDBuildsAdvance(t *testing.T) {
-
 	examplePath, err := filepath.Abs(filepath.Join("..", "example"))
 	if err != nil {
 		t.Fatalf("Unable to determine example path: %v", err)
@@ -58,6 +57,9 @@ func TestCWDBuildsAdvance(t *testing.T) {
 	// Amount of time we're willing to wait for a state transition.
 	const timeout = 30 * time.Second
 	deadline := time.Now().Add(timeout)
+
+	// State machine. If we see a certain string, what string do we expect
+	// to see next?
 
 	current := ""
 	wanted := "Hello from hanoverd_0\r\n"
@@ -130,7 +132,6 @@ loop:
 }
 
 func TestMultiplePortPolling(t *testing.T) {
-
 	examplePath, err := filepath.Abs(filepath.Join("multiple-ports"))
 	if err != nil {
 		t.Fatalf("Unable to determine multiple-ports path: %v", err)
@@ -151,7 +152,9 @@ func TestMultiplePortPolling(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		time.Sleep(60 * time.Second)
+		// How long to keep invoking SIGHUP for in a loop?
+		const testLength = 1 * time.Minute
+		time.Sleep(testLength)
 		cmd.Process.Signal(syscall.SIGTERM)
 	}()
 
@@ -191,5 +194,4 @@ loop:
 	if err != nil {
 		t.Fatalf("waiting on hanoverd: %v", err)
 	}
-
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -17,10 +17,16 @@ const (
 	testPort = "50820"
 )
 
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		DisableKeepAlives: true,
+	},
+}
+
 // simpleGetHTTP returns the body of a HTTP GET response from `url`, or an
 // empty string on error.
 func simpleGetHTTP(url string) string {
-	r, err := http.Get(url)
+	r, err := httpClient.Get(url)
 	if r != nil && r.Body != nil {
 		defer r.Body.Close()
 	}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -186,6 +186,12 @@ loop:
 			seenOne = true
 		}
 
+		select {
+		case <-done:
+			break loop
+		default:
+		}
+
 		log.Printf("Got response from server: %q", response)
 
 		if seenOne && response == "" {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -68,6 +68,18 @@ func TestCWDBuildsAdvance(t *testing.T) {
 		"Hello from hanoverd_2\r\n": "",
 	}
 
+	finished := make(chan struct{})
+	defer close(finished)
+
+	go func() {
+		select {
+		case <-time.After(timeout):
+			cmd.Process.Signal(syscall.SIGQUIT)
+
+		case <-finished:
+		}
+	}()
+
 	// Rapidly loop doing HTTP requests.
 loop:
 	for {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -158,6 +158,8 @@ func TestMultiplePortPolling(t *testing.T) {
 	start := time.Now()
 	lastResponse := ""
 
+	seenOne := false
+
 loop:
 	for {
 		select {
@@ -172,6 +174,15 @@ loop:
 			lastResponse = response
 			start = time.Now()
 			cmd.Process.Signal(syscall.SIGHUP)
+			seenOne = true
+		}
+
+		log.Printf("Got response from server: %q", response)
+
+		if seenOne && response == "" {
+			t.Errorf("Received empty response from server. Handover failure?")
+			cmd.Process.Signal(syscall.SIGTERM)
+			break loop
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -21,6 +21,9 @@ const (
 // empty string on error.
 func simpleGetHTTP(url string) string {
 	r, err := http.Get(url)
+	if r != nil && r.Body != nil {
+		defer r.Body.Close()
+	}
 	if err != nil {
 		return ""
 	}

--- a/tests/multiple-ports/Dockerfile
+++ b/tests/multiple-ports/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.6
+
+CMD ["multiple-ports"]
+EXPOSE 80 443
+
+COPY . /go/src/multiple-ports
+RUN go install -v multiple-ports

--- a/tests/multiple-ports/main.go
+++ b/tests/multiple-ports/main.go
@@ -27,6 +27,8 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		hostname, _ := os.Hostname()
 		fmt.Fprintln(w, hostname)
+
+		time.Sleep(50 * time.Millisecond)
 	})
 
 	server := http.Server{TLSConfig: cfg}

--- a/tests/multiple-ports/main.go
+++ b/tests/multiple-ports/main.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -24,7 +25,8 @@ func main() {
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "OK")
+		hostname, _ := os.Hostname()
+		fmt.Fprintln(w, hostname)
 	})
 
 	server := http.Server{TLSConfig: cfg}

--- a/tests/multiple-ports/main.go
+++ b/tests/multiple-ports/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"time"
+)
+
+func main() {
+	cfg, err := InitializeTLS("127.0.0.1")
+	if err != nil {
+		log.Fatalf("Error in InitializeTLS: %v", err)
+	}
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "OK")
+	})
+
+	server := http.Server{TLSConfig: cfg}
+	server.ErrorLog = log.New(ioutil.Discard, "", 0)
+
+	go func() { log.Fatal(server.ListenAndServeTLS("", "")) }()
+	log.Fatal(http.ListenAndServe(":http", nil))
+}
+
+// InitializeTLS ...
+func InitializeTLS(internalIPStr string) (*tls.Config, error) {
+	internalIP := net.ParseIP(internalIPStr)
+	if internalIP == nil {
+		return nil, fmt.Errorf("Failed to parse IP %q", internalIPStr)
+	}
+
+	// This curve choice is fairly arbitrary and can be changed at a later
+	// date without too many consequences. It was chosen because @pwaller
+	// had seen it used elsewhere, so it at least has some significant
+	// use in the wild.
+	//
+	// Other considerations to take into account: performance, simplicity.
+	// In Mar 2016, P256 is the only one with an assembly implementation,
+	// so it is considerably faster than the other curves.
+	curve := elliptic.P256()
+
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &x509.Certificate{
+		// "the serial number must be unique for each certificate
+		//  issued by a specific CA (as mentioned in RFC 2459)."
+		// Since every server start is its own CA, this can just be 0.
+		SerialNumber: big.NewInt(0),
+
+		Subject: pkix.Name{
+			OrganizationalUnit: []string{"Test"},
+			CommonName:         "TLSPrivateAddress",
+		},
+
+		NotBefore: time.Now().Add(-24 * time.Hour), // 1 day ago, in case of clock drift.
+		NotAfter:  time.Now().AddDate(2, 0, 0),     // 2 years
+
+		BasicConstraintsValid: true,
+		IsCA:           true, // We are an authority for ourselves.
+		MaxPathLenZero: true, // We're a self signed cert.
+
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+			x509.ExtKeyUsageServerAuth,
+		},
+
+		IPAddresses: []net.IP{internalIP},
+	}
+
+	// Generate a self-signed certificate (c passed twice).
+	certData, err := x509.CreateCertificate(rand.Reader, c, c, key.Public(), key)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := asTLSCertificate(certData, key)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+
+		// Certificate verification happens elsewhere!
+		// ClientAuth: tls.RequireAnyClientCert,
+		ClientAuth: tls.RequestClientCert,
+	}
+
+	return cfg, nil
+}
+
+func asTLSCertificate(
+	certData []byte,
+	key *ecdsa.PrivateKey,
+) (tls.Certificate, error) {
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certData,
+	})
+
+	keyData, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "ECDSA PRIVATE KEY",
+		Bytes: keyData,
+	})
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	cert.Leaf, err = x509.ParseCertificate(certData)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	return cert, nil
+}


### PR DESCRIPTION
This PR contains two significant changes:

* Introduce a configurable grace period before killing the old server process.
* Introduce a new method for detecting when the process being run is ready.

We also introduce a stress test to make sure these things work correctly.

# Grace period before killing old server

The main motivation for this is so that the new integration test can check that there are no holes during an overlap.

ce7976892aed8f7082dcdf2bf5037e357c8af97e introduces the change. During a flip, rather than issuing the kill immediately, we wait for `--overlap-grace-duration` before doing so.

Because the iptables rules only affect connection establishment (and not ongoing connections), this period allows existing connections to complete, so long as they do so within the grace period. This reduces the number of broken connections that would be caused by a handover.

However, because of HTTP keep-alive, some connections may last longer and therefore be killed anyway. A more complete solution would require notifying the child process to stop idle keep-alive connections, which is more involved so I haven't done this for now.

# Detecting process ready

*Old method:*

* Loop over result of `PortMappingAPI()`
* Pick the first one
* Make rapid HTTP requests to this port (@ `--status-uri`)
* Success when 200 OK
* Retry on network error
* Error for anything else
* Time out after 5 minutes.

*Problem:*

We added a port which doesn't speak HTTP, and it turns out that that
`PortMappingAPI()` returned that port. As a consequence, it would poll this
(wrong) port until giving up.

This may relate to the failures we have seen in production of the server
failing to update.

*Motivation:*

Hanoverd was intended to be auto-configuring in the sense that you shouldn't
need to specify much in order to make it work. I did consider making
`--status-uri` into `--status-url` instead, forcing the user to specify the
port. But this comes with other complications, because hanoverd can only
communicate on the public port, which is determined by docker. 
So we have to go through the `PortMappingAPI` anyway.

The other problem is that there are several of these in production already
and I don't want to modify the configuration semantics. ("It should just work").

*Solution:*

* Rather than querying just one port, we poll all exposed ports in parallel.
* If we encounter a malformed HTTP request, we assume that port doesn't speak
HTTP and stop polling just that port.
* A poller gives up if we get a response which is not 200 OK.
* So long as we are still polling at least one port, everything continues.
* Fail if there are no ports remaining.
* Success if any port response 200 OK on the `--status-uri` (default `/`).
* All polling halts when success or failure occurs.
* Time out after 5 minutes.

The only externality I am aware of is that we now send a HTTP request to ports
which don't take HTTP requests. This can result in error messages in the log
of the process being run.