### PR TITLE
Inject internal environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,18 @@ can be set first.
     DOCKER_HOST
     DOCKER_TLS_VERIFY
 
+Additionally, Hanoverd injects internal environment variables that can be used
+by the container:
+
+    HANOVERD_IMAGE
+    HANOVERD_IMAGE_REPO
+    HANOVERD_IMAGE_TAGDIGEST
+
 ## Method
 
 Hanoverd has a few phases. It commences this when it first starts or
 when it is signalled.
- 
+
 * Obtain image (can be done a few ways)
 * Start container with the new image
 * Rapidly poll container with requests until it gives a 200 response

--- a/container_test.go
+++ b/container_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+func TestImageRef(t *testing.T) {
+	data := map[string][]string{
+		"http://user:pass@localhost.localdomain:5000/org/hanoverd:master-0-g1234567": []string{
+			"http://user:pass@localhost.localdomain:5000/org/hanoverd", "master-0-g1234567",
+		},
+		"http://user:pass@localhost.localdomain:5000/hanoverd:master-0-g1234567": []string{
+			"http://user:pass@localhost.localdomain:5000/hanoverd", "master-0-g1234567",
+		},
+		"http://localhost.localdomain:5000/hanoverd:master-0-g1234567": []string{
+			"http://localhost.localdomain:5000/hanoverd", "master-0-g1234567",
+		},
+		"localhost.localdomain:5000/hanoverd:master-0-g1234567": []string{
+			"localhost.localdomain:5000/hanoverd", "master-0-g1234567",
+		},
+		"localhost.localdomain:5000/hanoverd@0123456789abcdef": []string{
+			"localhost.localdomain:5000/hanoverd", "0123456789abcdef",
+		},
+		"localhost.localdomain:5000/hanoverd": []string{
+			"localhost.localdomain:5000/hanoverd", "latest",
+		},
+		"localhost.localdomain/hanoverd:master-0-g1234567": []string{
+			"localhost.localdomain/hanoverd", "master-0-g1234567",
+		},
+		"localhost.localdomain/hanoverd@0123456789abcdef": []string{
+			"localhost.localdomain/hanoverd", "0123456789abcdef",
+		},
+		"localhost.localdomain/hanoverd": []string{
+			"localhost.localdomain/hanoverd", "latest",
+		},
+		"hanoverd:master-0-g1234567": []string{
+			"hanoverd", "master-0-g1234567",
+		},
+		"hanoverd@0123456789abcdef": []string{
+			"hanoverd", "0123456789abcdef",
+		},
+		"hanoverd": []string{
+			"hanoverd", "latest",
+		},
+		"": []string{
+			"", "latest",
+		},
+	}
+
+	for input, expected := range data {
+		givenName, givenTagDigest := imageRef(input)
+		if givenName != expected[0] || givenTagDigest != expected[1] {
+			t.Errorf("Expected: %s %s but got %s %s", expected[0], expected[1], givenName, givenTagDigest)
+		}
+	}
+}


### PR DESCRIPTION
These variables are prepended so can be overridden.

This is useful when the `ImageSource` is a `GitHostSource` or `DockerPullSource` and has the `imageName` format `{repo}:{git-describe}`, e.g. `seaeye:master-0-g92666e8`.