### PR TITLE
Installing missing netcat

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,3 +1,9 @@
 FROM ubuntu
+
+RUN set -x \
+ && apt-get update \
+ && apt-get install -y netcat-openbsd \
+ && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8000
 CMD ["sh", "-c", "while : ; do printf 'HTTP/1.0 200 OK\r\n\r\nHello from %s\r\n' $(hostname)| nc -l 8000; done"]

--- a/example/separate-build-run/Dockerfile
+++ b/example/separate-build-run/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:15.10
 
-RUN apt-get install -y netcat-openbsd
+RUN set -x \
+ && apt-get update \
+ && apt-get install -y netcat-openbsd \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /runtime
 


### PR DESCRIPTION
I can only assume the netcat-openbsd package was available in the
package cache on an older Ubuntu release?