### PR TITLE
WIP: Better handling of invalid tag names

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -66,6 +66,7 @@ func Action(_ context.Context, c *cli.Command) error {
 
 	build := func() error {
 		name, err2 := imageSource.Obtain(client, []byte{})
+		name = source.CleanDockerTag(name)
 		if err2 != nil {
 			return fmt.Errorf("obtain: %v", err2)
 		}


### PR DESCRIPTION
For some reason, in some rare cases, the tag name ends up as being the specific branch name, rather than the target. Not sure why. These extra checks are a workaround for invalid names making it to Docker.